### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,8 @@
 name: Code Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/hydrabeer/my2fa/security/code-scanning/3](https://github.com/hydrabeer/my2fa/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code) and uploads coverage reports to Codecov. Therefore, the `contents: read` permission is sufficient for most steps, and no additional write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
